### PR TITLE
Adding `-m32` option to gcc under Linux

### DIFF
--- a/examples/first.m4
+++ b/examples/first.m4
@@ -9,9 +9,9 @@ m4_include(`asm.m4')
 ; nasm -f coff first.asm
 ; gcc -o first first.o driver.c asm_io.o
 ;
-; Using Linux and gcc:
+; Using Linux and gcc (on x86_64):
 ; nasm -f elf first.asm
-; gcc -o first first.o driver.c asm_io.o
+; gcc -m32 -o first first.o driver.c asm_io.o
 ;
 ; Using Borland C/C++
 ; nasm -f obj first.asm


### PR DESCRIPTION
1- It will not successfully compile under 64-bit architecture if the `-m32` is not added. I guess (not sure though) the reason is a change in GCC where they [no longer allowed 32-bit absolute addressing](https://stackoverflow.com/questions/43367427/32-bit-absolute-addresses-no-longer-allowed-in-x86-64-linux#) on Linux x86_64. Also, One needs to install `gcc-multilib` and `g++-multilib` packages before-head, because the 32-bit version of libgcc [isn't available on the 64-bit gcc](https://stackoverflow.com/questions/34219248/usr-bin-ld-cannot-find-lgcc-error-in-the-linkage-of-assembly). This might also need to be added in the LaTex version of book, sections 1.4.4 and  1.4.5 

2- One more thing, assembling the `asm_io.asm` was not mentioned in section 1.4.3, although it is necessary, and it has a caveat where one needs to add the inline macro `-d ELF_TYPE`, this would only be noticed when reading the comments of the `asm_io.asm` file. For a beginner, and for his/her first code. this will hinder a bit, and distract the learner on a quest on the web trying to find a solutions.